### PR TITLE
StarkEx auth now as in native + append in generic GET POST our Bearer

### DIFF
--- a/src/lib/dvf/get-generic.js
+++ b/src/lib/dvf/get-generic.js
@@ -3,6 +3,7 @@ const _ = require('lodash')
 
 module.exports = async (dvf, endpoint, qs = {}, headers = {}) => {
   const url = dvf.config.api + endpoint
+  headers = { ...headers, Authorization: dvf.config.apiKey }
 
   const options = {
     uri: url,

--- a/src/lib/dvf/makeAuthHeaders.js
+++ b/src/lib/dvf/makeAuthHeaders.js
@@ -15,6 +15,5 @@ module.exports = (dvf, nonce, signature) => {
       : {}
     )
   }
-  return { Authorization: dvf.config.apiKey,
-    "GFM-StarkEx-Authorization": makeEcRecoverHeader(authData)}
+  return {"GFM-StarkEx-Authorization": makeEcRecoverHeader(authData)}
 }

--- a/src/lib/dvf/post-generic.js
+++ b/src/lib/dvf/post-generic.js
@@ -3,6 +3,7 @@ const _ = require('lodash')
 
 module.exports = async (dvf, endpoint, json = {}, headers = {}) => {
   const url = dvf.config.api + endpoint
+  headers = { ...headers, Authorization: dvf.config.apiKey }
 
   const options = {
     uri: url,


### PR DESCRIPTION
There are GET and POST generic methods.
Now MakeAuthHeaders works like in upstream (but the header var name is just used for what we accept - GFM-StarkEx-Authorization
get-generic and post-generic are now always append `Authorization: dvf.config.apiKey` header, so any request will use it (but we still need those where we put manually `Authorization: dvf.config.apiKey`)

In that case we keep adding Bearer token to any requests (some DVF methods has authentication by nonce+signature in body - see `addAuthHeadersOrData` 
```
  if (dvf.config.useAuthHeader || dvf.config.useTradingKey || dvf.config.useSignature) {
    headers = { ...headers, ...makeAuthHeaders(dvf, nonce, signature) }
  } else {
    data = { ...data, nonce, signature }
  }
```

